### PR TITLE
Update Dropbox to Version 11.25.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dropbox" %}
-{% set version = "11.14.0" %}
+{% set version = "11.25.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/dropbox/dropbox-sdk-python/archive/v{{ version }}.tar.gz
-  sha256: 010763f8536364af14b72d6c7380b839a5eadb3e7bfb99a2b76f6ab003f7989d
+  sha256: 54bfe5902b8cb26d2f70b2ee8bda92cd61a084d1672e19af3d60d04a36e8bee1
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,13 +24,14 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python
+    - python >=3.7
     - requests >=2.16.2
     - six >=1.12.0
     - stone >=2.*
 
 test:
   requires:
+    - python <3.10
     - pip
     - mock
     - pytest-mock


### PR DESCRIPTION

  `dropbox` version `11.25.0`
1. check the upstream
    https://github.com/dropbox/dropbox-sdk-python/tree/v11.25.0

2. check the pinnings
    https://github.com/dropbox/dropbox-sdk-python/blob/main/tox.ini
    https://github.com/dropbox/dropbox-sdk-python/blob/main/setup.py
    https://github.com/dropbox/dropbox-sdk-python/blob/main/setup.cfg
    https://github.com/dropbox/dropbox-sdk-python/blob/main/ez_setup.py

3. check the changelogs
    https://github.com/dropbox/dropbox-sdk-python/blob/v11.25.0/UPGRADING.md

    There were no breaking changes mentioned in the documentation

4. additional research
    https://github.com/conda-forge/dropbox-feedstock/issues

    There were no open issues in conda forge

5. verify dev_url
    https://github.com/dropbox/dropbox-sdk-python

6. verify doc_url
    https://dropbox-sdk-python.readthedocs.io/en/latest/

7. pip in the test section
8. veriy the test section
9. additional tests

In order to test the `dropbox` package version `11.25.0` the folowing
command was used:
`conda build dropbox-feedstock --test`
the test result was the following:
`All tests passed`
