### PR TITLE
modify the python pinning for the run section for Dropbox version 11.25.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,9 +35,6 @@ test:
     - mock
     - pytest-mock
     - coverage
-    - pytest
-    - coverage
-    - stone >=2.*
   imports:
     - dropbox
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python >=3.7
+    - python
     - requests >=2.16.2
     - six >=1.12.0
     - stone >=2.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 0
-  skip: True  # [win]
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION

`dropbox` version `11.25.0`

check the upstream
https://github.com/dropbox/dropbox-sdk-python/tree/v11.25.0

check the pinnings
https://github.com/dropbox/dropbox-sdk-python/blob/main/tox.ini
https://github.com/dropbox/dropbox-sdk-python/blob/main/setup.py
https://github.com/dropbox/dropbox-sdk-python/blob/main/setup.cfg
https://github.com/dropbox/dropbox-sdk-python/blob/main/ez_setup.py

check the changelogs
https://github.com/dropbox/dropbox-sdk-python/blob/v11.25.0/UPGRADING.md

There were no breaking changes mentioned in the documentation

additional research
https://github.com/conda-forge/dropbox-feedstock/issues

There were no open issues in conda forge

verify dev_url
https://github.com/dropbox/dropbox-sdk-python

verify doc_url
https://dropbox-sdk-python.readthedocs.io/en/latest/

pip in the test section

veriy the test section

additional tests

In order to test the dropbox package version 11.25.0 the folowing
command was used:
`conda build dropbox-feedstock --test`
the test result was the following:
`All tests passed`