### PR TITLE
rebuild `dropbox` version `11.25.0` for noarch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 54bfe5902b8cb26d2f70b2ee8bda92cd61a084d1672e19af3d60d04a36e8bee1
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION

`dropbox` version `11.25.0`

check the upstream
https://github.com/dropbox/dropbox-sdk-python/tree/v11.25.0

check the pinnings
https://github.com/dropbox/dropbox-sdk-python/blob/main/tox.ini
https://github.com/dropbox/dropbox-sdk-python/blob/main/setup.py
https://github.com/dropbox/dropbox-sdk-python/blob/main/setup.cfg
https://github.com/dropbox/dropbox-sdk-python/blob/main/ez_setup.py

check the changelogs
https://github.com/dropbox/dropbox-sdk-python/blob/v11.25.0/UPGRADING.md

There were no breaking changes mentioned in the documentation

additional research
https://github.com/conda-forge/dropbox-feedstock/issues

There were no open issues in conda forge

verify dev_url
https://github.com/dropbox/dropbox-sdk-python

verify doc_url
https://dropbox-sdk-python.readthedocs.io/en/latest/

pip in the test section

veriy the test section

additional tests

In order to test the `dropbox` package version `11.25.0` the folowing
command was used:
`conda build dropbox-feedstock --test`
the test result was the following:
`All tests passed`