### PR TITLE
Update `Dropbox` to version `11.25.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 54bfe5902b8cb26d2f70b2ee8bda92cd61a084d1672e19af3d60d04a36e8bee1
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/recipe_clobber.yaml
+++ b/recipe/recipe_clobber.yaml
@@ -1,2 +1,2 @@
 build:
-  noarch: false
+  noarch: true


### PR DESCRIPTION
To build the dropbox package as a `noarch` package we had to modify the `recipe_clobber.yaml` file to allow for the package to be build as a `noarch`