### PR TITLE
dropbox 11.36.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 
 build:
   number: 0
+  # stone package is not available on s390x
+  skip: true  # [linux and s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dropbox" %}
-{% set version = "11.25.0" %}
+{% set version = "11.36.1" %}
 
 
 package:
@@ -8,12 +8,11 @@ package:
 
 source:
   url: https://github.com/dropbox/dropbox-sdk-python/archive/v{{ version }}.tar.gz
-  sha256: 54bfe5902b8cb26d2f70b2ee8bda92cd61a084d1672e19af3d60d04a36e8bee1
+  sha256: 29e57afad30db4bba282dbb38a30e77565b9524944c69502a891965d0aaad0ac
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -26,7 +25,7 @@ requirements:
     - python
     - requests >=2.16.2
     - six >=1.12.0
-    - stone >=2.*
+    - stone >=2
 
 test:
   requires:
@@ -44,7 +43,7 @@ test:
     - test
 
 about:
-  home: http://www.dropbox.com/developers
+  home: https://www.dropbox.com/developers
   summary: Official Dropbox API Client
   description: The Official Dropbox API V2 SDK for Python
   license: MIT

--- a/recipe/recipe_clobber.yaml
+++ b/recipe/recipe_clobber.yaml
@@ -1,2 +1,0 @@
-build:
-  noarch: true


### PR DESCRIPTION
Changelog: https://github.com/dropbox/dropbox-sdk-python/releases
License: https://github.com/dropbox/dropbox-sdk-python/blob/v11.36.1/LICENSE
Requirements:
- https://github.com/dropbox/dropbox-sdk-python/blob/v11.36.1/setup.py
- https://github.com/dropbox/dropbox-sdk-python/blob/v11.36.1/requirements.txt

Actions:
1. Add `--no-deps --no-build-isolation` flags to script
2. Skip `s390x` because of missing `stone` package
3. Fix `stone` pinning
4. Fix home url

